### PR TITLE
Add CI (from Brainstorm4266)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,8 @@
 name: Rust
 
 on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+  - push
+  - pull_request
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR specifically bypasses the requirement of the Proc Macros to be complete before merging of the CI tests.

Methods which obfuscate the origin of the commits has been deliberately **avoided** (note the "partially verified" - I've committed Brainstorm's commits but not authored them - this causes a bit of confusion in the UI).

**Triage team edits:** closes #46 